### PR TITLE
Updating Makefile for compatibility with GCC-6.3.0

### DIFF
--- a/CAVIAR-C++/Makefile
+++ b/CAVIAR-C++/Makefile
@@ -1,7 +1,7 @@
 CC=g++
 DIC=$(PWD)
 CFLAGS=-c -Wall -g  -I $(DIC) 
-LDFLAGS= -I $(DIC)/armadillo/include/ -DARMA_DONT_USE_WRAPPER -llapack -lblas -lgslcblas  -lgsl
+LDFLAGS= -I $(DIC)/armadillo/include/ -DARMA_DONT_USE_WRAPPER -llapack -lblas -lgslcblas  -lgsl -lgfortran
 SOURCES1=caviar.cpp PostCal.cpp Util.cpp TopKSNP.cpp 
 SOURCES2=ecaviar.cpp PostCal.cpp Util.cpp
 SOURCES3=setcaviar.cpp PostCal.cpp Util.cpp


### PR DESCRIPTION
This fixes a compilation issue that occurs under GCC 6.3.0 on RHEL7 due to a missing flag to include libgfortran. The original error message was:

    /usr/bin/ld: .../lapack/gcc/64/3.7.0/liblapack.so(xerbla.o): undefined reference to symbol '_gfortran_transfer_character_write@@GFORTRAN_1.4'
    .../lib64/libgfortran.so.3: error adding symbols: DSO missing from command line

After adding the additional `-lgfortran` flag to the Makefile the application compiles as expected